### PR TITLE
Kernel: Fix incompatible char types wldev_common

### DIFF
--- a/drivers/net/wireless/bcmdhd/wldev_common.c
+++ b/drivers/net/wireless/bcmdhd/wldev_common.c
@@ -341,9 +341,9 @@ int wldev_set_country(
 	int error = -1;
 	wl_country_t cspec = {{0}, 0, {0}};
 
-		country_code = "US";
-		cspec.ccode = "US";
-		cspec.country_abbrev = "US";
+		strcpy(country_code, "US");
+		strcpy(cspec.ccode, "US");
+		strcpy(cspec.country_abbrev, "US");
 		cspec.rev = 46;
 		dhd_bus_country_set(dev, &cspec, notify);
 		WLDEV_ERROR(("%s: set country for %s as %s rev %d\n",


### PR DESCRIPTION
Build fails for branch cm-13 due to

```
incompatible types when assigning to type 'char[4]' from type 'char *'
```
